### PR TITLE
fix #23 issue with paths for pypdf2

### DIFF
--- a/R/combine_pdfs.R
+++ b/R/combine_pdfs.R
@@ -24,10 +24,16 @@ combine_pdfs <- function(input_paths, output_path) {
   assertthat::assert_that(all(fs::file_exists(input_paths)))
   assertthat::assert_that(fs::dir_exists(fs::path_dir(output_path)))
 
+  # replace `~` with users home directory for PyPDF2
+  input_paths <- fs::path_expand(input_paths)
+  output_path <- fs::path_expand(output_path)
+
   # load `combine_pdfs_py` into environment
-  reticulate::source_python(
-    file = system.file("python/combine_pdfs.py", package = utils::packageName())
+  combine_pdfs_py_fpath <- system.file(
+    "python/combine_pdfs.py",
+    package = utils::packageName()
   )
+  reticulate::source_python(file = combine_pdfs_py_fpath)
 
   combine_pdfs_py(input_paths, output_path)
 }

--- a/R/combine_pdfs.R
+++ b/R/combine_pdfs.R
@@ -24,9 +24,9 @@ combine_pdfs <- function(input_paths, output_path) {
   assertthat::assert_that(all(fs::file_exists(input_paths)))
   assertthat::assert_that(fs::dir_exists(fs::path_dir(output_path)))
 
-  # replace `~` with users home directory for PyPDF2
-  input_paths <- fs::path_expand(input_paths)
-  output_path <- fs::path_expand(output_path)
+  # eliminate any symbolic links and special references like '~' or '..' for PyPDF2
+  input_paths <- fs::path_real(input_paths)
+  output_path <- fs::path_real(output_path)
 
   # load `combine_pdfs_py` into environment
   combine_pdfs_py_fpath <- system.file(


### PR DESCRIPTION
## Describe changes

Fixes issue with paths for pypdf2. Documented more in the issue https://github.com/ihmeuw-demographics/demUtils/issues/23

## What issues are related

Fixes #23 

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [X] Have you successfully run `devtools::check()` locally?
* [x] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [ ] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.

## Details of PR

The current test for this function uses the temp directory, I'm not sure we want a test writing in the home directory?