### PR TITLE
Fix installation of PyPDF2 dependency for github action workflow

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -74,6 +74,8 @@ jobs:
       - name: Install python package dependencies
         run: |
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
+          Rscript -e "reticulate::install_miniconda()"
+          Rscript -e "reticulate::conda_create('r-reticulate')"
 
       - name: Check
         env:

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -67,7 +67,7 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - uses actions/setup-python@v2
+      - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
 

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -76,7 +76,7 @@ jobs:
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate')"
-          conda install PyPDF2 -n r-reticulate
+          Rscript -e "reticulate::conda_install(envname='r-reticulate', packages="PyPDF2")"
 
       - name: Check
         env:

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -76,6 +76,7 @@ jobs:
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate')"
+          conda install PyPDF2 -n r-reticulate
 
       - name: Check
         env:

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -67,10 +67,13 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Install reticulate dependencies
+      - uses actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install python package dependencies
         run: |
-          Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate')"
+          python3 -m pip --no-cache-dir install --upgrade PyPDF2
 
       - name: Check
         env:

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -76,7 +76,7 @@ jobs:
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate')"
-          Rscript -e "reticulate::conda_install(envname='r-reticulate', packages="PyPDF2")"
+          Rscript -e "reticulate::conda_install(envname='r-reticulate', packages='PyPDF2')"
 
       - name: Check
         env:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -45,7 +45,7 @@ jobs:
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate')"
-          Rscript -e "reticulate::conda_install(envname='r-reticulate', packages="PyPDF2")"
+          Rscript -e "reticulate::conda_install(envname='r-reticulate', packages='PyPDF2')"
 
       - name: Install package
         run: R CMD INSTALL .

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,7 +36,7 @@ jobs:
           install.packages("pkgdown")
         shell: Rscript {0}
 
-      - uses actions/setup-python@v2
+      - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,10 +36,13 @@ jobs:
           install.packages("pkgdown")
         shell: Rscript {0}
 
-      - name: Install reticulate dependencies
+      - uses actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install python package dependencies
         run: |
-          Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate')"
+          python3 -m pip --no-cache-dir install --upgrade PyPDF2
 
       - name: Install package
         run: R CMD INSTALL .

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -43,6 +43,8 @@ jobs:
       - name: Install python package dependencies
         run: |
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
+          Rscript -e "reticulate::install_miniconda()"
+          Rscript -e "reticulate::conda_create('r-reticulate')"
 
       - name: Install package
         run: R CMD INSTALL .

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -45,6 +45,7 @@ jobs:
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate')"
+          conda install PyPDF2 -n r-reticulate
 
       - name: Install package
         run: R CMD INSTALL .

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -45,7 +45,7 @@ jobs:
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate')"
-          conda install PyPDF2 -n r-reticulate
+          Rscript -e "reticulate::conda_install(envname='r-reticulate', packages="PyPDF2")"
 
       - name: Install package
         run: R CMD INSTALL .

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -50,6 +50,7 @@ jobs:
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate')"
+          conda install PyPDF2 -n r-reticulate
 
       - name: Test coverage
         run: covr::codecov()

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -41,10 +41,13 @@ jobs:
           remotes::install_cran("covr")
         shell: Rscript {0}
 
-      - name: Install reticulate dependencies
+      - uses actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install python package dependencies
         run: |
-          Rscript -e "reticulate::install_miniconda()"
-          Rscript -e "reticulate::conda_create('r-reticulate')"
+          python3 -m pip --no-cache-dir install --upgrade PyPDF2
 
       - name: Test coverage
         run: covr::codecov()

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -50,7 +50,7 @@ jobs:
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate')"
-          Rscript -e "reticulate::conda_install(envname='r-reticulate', packages="PyPDF2")"
+          Rscript -e "reticulate::conda_install(envname='r-reticulate', packages='PyPDF2')"
 
       - name: Test coverage
         run: covr::codecov()

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -41,7 +41,7 @@ jobs:
           remotes::install_cran("covr")
         shell: Rscript {0}
 
-      - uses actions/setup-python@v2
+      - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -50,7 +50,7 @@ jobs:
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
           Rscript -e "reticulate::install_miniconda()"
           Rscript -e "reticulate::conda_create('r-reticulate')"
-          conda install PyPDF2 -n r-reticulate
+          Rscript -e "reticulate::conda_install(envname='r-reticulate', packages="PyPDF2")"
 
       - name: Test coverage
         run: covr::codecov()

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -48,6 +48,8 @@ jobs:
       - name: Install python package dependencies
         run: |
           python3 -m pip --no-cache-dir install --upgrade PyPDF2
+          Rscript -e "reticulate::install_miniconda()"
+          Rscript -e "reticulate::conda_create('r-reticulate')"
 
       - name: Test coverage
         run: covr::codecov()


### PR DESCRIPTION
## Describe changes

Switch to installing python using standard action and install 'PyPDF2' dependency directly.

## What issues are related

Fixes #17 

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [ ] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [x] Have you successfully run `devtools::check()` locally?
* [ ] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [x] Have you added in tests for the changes included in the PR?
* [x] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.

## Details of PR

Initially tried to follow reticulate directions to automatically install R package python dependencies but these don't seem to work easily.

https://rstudio.github.io/reticulate/articles/package.html
https://rstudio.github.io/reticulate/articles/python_dependencies.html
