### PR TITLE
make 'summarize_dt' work with multiple value columns

### DIFF
--- a/R/summarize_dt.R
+++ b/R/summarize_dt.R
@@ -26,7 +26,9 @@
 #' @return \[`data.table()`\] with `id_cols` (minus the `summarize_cols`) plus
 #'   summary statistic columns. The summary statistic columns have the same name
 #'   as each function specified in `summary_fun` and the quantiles are named
-#'   like 'q_`(probs * 100)`'.
+#'   like 'q_`(probs * 100)`'. If more than one `value_cols` is specified, each
+#'   of the summary statistic columns that are returned are prefixed with the
+#'   value column name.
 #'
 #' @details
 #' `summary_fun` correspond to names of functions in R that can take a vector of

--- a/R/summarize_dt.R
+++ b/R/summarize_dt.R
@@ -11,8 +11,10 @@
 #' @param summarize_cols \[`character()`\]\cr
 #'   The `id_cols` that should be collapsed and to calculate summary statistics
 #'   over.
-#' @param value_col \[`character(1)`\]\cr
-#'   Value column that summary statistics should be calculated for.
+#' @param value_cols \[`character()`\]\cr
+#'   Value columns that summary statistics should be calculated for. When more
+#'   than one column is specified, each of the summary statistic columns that
+#'   are returned are prefixed with the value column name.
 #' @param summary_fun \[`character()`\]\cr
 #'   Names of the functions that can be used to summarize a vector of values.
 #'   Default is "mean".
@@ -37,27 +39,29 @@
 #' data.table.
 #'
 #' @examples
-#' input_dt <- data.table::data.table(location = "USA",
-#'                                    draw = 1:101,
-#'                                    value = 0:100)
-#' output_dt <- summarize_dt(dt = input_dt,
-#'                           id_cols = c("location", "draw"),
-#'                           summarize_cols = "draw",
-#'                           value_col = "value")
+#' input_dt <- data.table::data.table(location = "USA", draw = 1:101, value = 0:100)
+#' output_dt <- summarize_dt(
+#'   dt = input_dt,
+#'   id_cols = c("location", "draw"),
+#'   summarize_cols = "draw",
+#'   value_cols = "value"
+#' )
 #'
 #' # no quantiles calculated
-#' output_dt <- summarize_dt(dt = input_dt,
-#'                           id_cols = c("location", "draw"),
-#'                           summarize_cols = "draw",
-#'                           value_col = "value",
-#'                           probs = NULL)
+#' output_dt <- summarize_dt(
+#'   dt = input_dt,
+#'   id_cols = c("location", "draw"),
+#'   summarize_cols = "draw",
+#'   value_cols = "value",
+#'   probs = NULL
+#')
 #'
 #' @importFrom methods existsFunction
 #' @export
 summarize_dt <- function(dt,
                          id_cols,
                          summarize_cols,
-                         value_col,
+                         value_cols,
                          summary_fun = c("mean"),
                          probs = c(0.025, 0.975)) {
 
@@ -66,8 +70,8 @@ summarize_dt <- function(dt,
   # check `summarize_cols` argument
   assertive::assert_is_character(summarize_cols)
 
-  # check `value_col` argument
-  assertthat::assert_that(assertthat::is.string(value_col))
+  # check `value_cols` argument
+  assertive::assert_is_character(value_cols)
 
   # check `id_cols` argument
   assertive::assert_is_character(id_cols)
@@ -76,7 +80,7 @@ summarize_dt <- function(dt,
 
   # check `dt` argument
   assertive::assert_is_data.table(dt)
-  assertable::assert_colnames(dt, c(id_cols, value_col), only_colnames = F,
+  assertable::assert_colnames(dt, c(id_cols, value_cols), only_colnames = F,
                               quiet = T)
   assert_is_unique_dt(dt, id_cols)
 
@@ -103,14 +107,27 @@ summarize_dt <- function(dt,
   original_keys <- original_keys[!original_keys %in% summarize_cols]
   if (is.null(original_keys)) original_keys <- by_id_cols
 
-  summary <- dt[, c(
-    if (length(summary_fun) > 0) lapply(sapply(summary_fun, get),
-                                        function(fun) fun(get(value_col))),
-    if (length(probs) > 0) as.list(stats::quantile(get(value_col),
-                                                   probs = probs))
-  ), by = by_id_cols]
-  data.table::setnames(summary, c(by_id_cols, summary_fun,
-                                  if (length(probs) > 0) quantile_names))
-  data.table::setkeyv(summary, original_keys)
-  return(summary)
+  funs <- sapply(summary_fun, get)
+
+  summaries <- lapply(value_cols, function(value_col) {
+    summary <- dt[
+      ,
+      c(
+        if (length(summary_fun) > 0) lapply(funs, function(fun) fun(get(value_col))),
+        if (length(probs) > 0) as.list(stats::quantile(get(value_col), probs = probs))
+      ),
+      by = by_id_cols
+    ]
+
+    summary_value_cols <- c(summary_fun, if (length(probs) > 0) quantile_names)
+    if (length(value_cols) > 1) {
+      summary_value_cols <- paste0(value_col, "_", summary_value_cols)
+    }
+
+    data.table::setnames(summary, c(by_id_cols, summary_value_cols))
+    data.table::setkeyv(summary, original_keys)
+  })
+  summaries <- Reduce(f = merge, x = summaries)
+
+  return(summaries)
 }

--- a/man/summarize_dt.Rd
+++ b/man/summarize_dt.Rd
@@ -42,7 +42,9 @@ quantiles with \code{stats::quantile()}. Default is 0.025 and 0.975 for the
 [\code{data.table()}] with \code{id_cols} (minus the \code{summarize_cols}) plus
 summary statistic columns. The summary statistic columns have the same name
 as each function specified in \code{summary_fun} and the quantiles are named
-like 'q_\code{(probs * 100)}'.
+like 'q_\code{(probs * 100)}'. If more than one \code{value_cols} is specified, each
+of the summary statistic columns that are returned are prefixed with the
+value column name.
 }
 \description{
 Calculate summary statistics when collapsing over a certain

--- a/man/summarize_dt.Rd
+++ b/man/summarize_dt.Rd
@@ -8,7 +8,7 @@ summarize_dt(
   dt,
   id_cols,
   summarize_cols,
-  value_col,
+  value_cols,
   summary_fun = c("mean"),
   probs = c(0.025, 0.975)
 )
@@ -24,8 +24,10 @@ ID columns that uniquely identify each row of \code{dt}.}
 The \code{id_cols} that should be collapsed and to calculate summary statistics
 over.}
 
-\item{value_col}{[\code{character(1)}]\cr
-Value column that summary statistics should be calculated for.}
+\item{value_cols}{[\code{character()}]\cr
+Value columns that summary statistics should be calculated for. When more
+than one column is specified, each of the summary statistic columns that
+are returned are prefixed with the value column name.}
 
 \item{summary_fun}{[\code{character()}]\cr
 Names of the functions that can be used to summarize a vector of values.
@@ -58,19 +60,21 @@ quantiles for using the \code{stats::quantile()} function. The default 2.5 and
 data.table.
 }
 \examples{
-input_dt <- data.table::data.table(location = "USA",
-                                   draw = 1:101,
-                                   value = 0:100)
-output_dt <- summarize_dt(dt = input_dt,
-                          id_cols = c("location", "draw"),
-                          summarize_cols = "draw",
-                          value_col = "value")
+input_dt <- data.table::data.table(location = "USA", draw = 1:101, value = 0:100)
+output_dt <- summarize_dt(
+  dt = input_dt,
+  id_cols = c("location", "draw"),
+  summarize_cols = "draw",
+  value_cols = "value"
+)
 
 # no quantiles calculated
-output_dt <- summarize_dt(dt = input_dt,
-                          id_cols = c("location", "draw"),
-                          summarize_cols = "draw",
-                          value_col = "value",
-                          probs = NULL)
+output_dt <- summarize_dt(
+  dt = input_dt,
+  id_cols = c("location", "draw"),
+  summarize_cols = "draw",
+  value_cols = "value",
+  probs = NULL
+)
 
 }

--- a/tests/testthat/test-summarize_dt.R
+++ b/tests/testthat/test-summarize_dt.R
@@ -1,26 +1,57 @@
 library(data.table)
 library(testthat)
 
+# Basic test with one value column ----------------------------------------
+
 # set up test input data.table
-input_dt <- CJ(location = "USA",
-               year = 1950:2010,
-               draw = 1:101)
-input_dt[, value := draw - 1]
+input_dt <- CJ(location = "USA", year = 1950:2010, draw = 1:101)
+input_dt[, deaths := draw - 1]
+input_dt[, population := deaths * 2]
 
 # set up expected output table
-expected_dt <- CJ(location = sort(unique(input_dt$location)),
-                  year = sort(unique(input_dt$year)),
-                  mean = 50, median = 50, sd = sd(0:100),
-                  min = 0, max = 100,
-                  q2.5 = 2.5, q10 = 10, q90 = 90, q97.5 = 97.5)
+expected_dt <- CJ(
+  location = "USA",
+  year = 1950:2010,
+  mean = 50, median = 50, sd = sd(0:100),
+  min = 0, max = 100,
+  q2.5 = 2.5, q10 = 10, q90 = 90, q97.5 = 97.5
+)
 setkeyv(expected_dt, c("location", "year"))
 
-test_that("calculating summary statistics works", {
-  output_dt <- summarize_dt(dt = input_dt,
-                            id_cols = c("location", "year", "draw"),
-                            summarize_cols = c("draw"),
-                            value_col = "value",
-                            summary_fun = c("mean", "median", "sd", "min", "max"),
-                            probs = c(0.025, 0.1, 0.9, 0.975))
+test_that("calculating summary statistics works with one value column", {
+  output_dt <- summarize_dt(
+    dt = input_dt,
+    id_cols = c("location", "year", "draw"),
+    summarize_cols = c("draw"),
+    value_cols = "deaths",
+    summary_fun = c("mean", "median", "sd", "min", "max"),
+    probs = c(0.025, 0.1, 0.9, 0.975)
+  )
+  expect_identical(output_dt, expected_dt)
+})
+
+# Test with multiple value columns ----------------------------------------
+
+stat_cols <- setdiff(names(expected_dt), c("location", "year"))
+
+expected_dt_deaths <- copy(expected_dt)
+setnames(expected_dt_deaths, stat_cols, paste0("deaths_", stat_cols))
+
+expected_dt_population <- copy(expected_dt)
+expected_dt_population[, (stat_cols) := lapply(stat_cols, function(col) get(col) * 2)]
+expected_dt_population[, sd := sd(seq(0, 200, by = 2))]
+setnames(expected_dt_population, stat_cols, paste0("population_", stat_cols))
+
+expected_dt <- merge(expected_dt_deaths, expected_dt_population)
+
+test_that("calculating summary statistics works with two value columns", {
+  output_dt <- summarize_dt(
+    dt = input_dt,
+    id_cols = c("location", "year", "draw"),
+    summarize_cols = c("draw"),
+    value_cols = c("deaths", "population"),
+    summary_fun = c("mean", "median", "sd", "min", "max"),
+    probs = c(0.025, 0.1, 0.9, 0.975)
+  )
   expect_identical(output_dt, expected_dt)
 })


### PR DESCRIPTION
## Describe changes

Make `summarize_dt` work with multiple value columns so that the user doesn't have to manually call the function multiple times.

This has a breaking change, since the argument `value_col` is changed to `value_cols`. Here are all the places that would need to be updated https://github.com/search?p=2&q=org%3Aihmeuw-demographics+summarize_dt&type=Code. It looks like popMethods and anything that used `model_template`.

Maybe can introduce this change in the next docker builds?

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [X] Have you successfully run `devtools::check()` locally?
* [X] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [X] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [X] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.
