### PR TITLE
assertive to checkmate for R 4.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Imports:
     data.table,
     dplyr,
     assertthat,
-    assertive,
     assertable (>= 0.2.7),
     checkmate,
     methods,

--- a/R/assert_is_unique_dt.R
+++ b/R/assert_is_unique_dt.R
@@ -44,11 +44,11 @@ identify_non_unique_dt <- function(dt, id_cols) {
   # Validate arguments ------------------------------------------------------
 
   # check `id_cols` argument
-  assertive::assert_is_character(id_cols)
+  checkmate::assert_character(id_cols)
 
   # check `dt` argument
-  assertive::assert_is_data.table(dt)
-  assertable::assert_colnames(dt, id_cols, only_colnames = F, quiet = T)
+  checkmate::assert_data_table(dt)
+  checkmate::assert_names(names(dt), must.include = id_cols)
 
   # Count number of rows in each combination of `id_cols` -------------------
 

--- a/R/change_col_type.R
+++ b/R/change_col_type.R
@@ -26,10 +26,10 @@ change_col_type <- function(dt,
                             is_fun = is.integer,
                             as_fun = as.numeric) {
 
-  assertive::is_data.table(dt)
-  assertive::is_character(check_cols)
-  assertive::is_function(is_fun)
-  assertive::is_function(as_fun)
+  checkmate::assert_data_table(dt)
+  checkmate::assert_character(check_cols)
+  checkmate::assert_function(is_fun)
+  checkmate::assert_function(as_fun)
 
   # subset to columns in dt
   if (length(check_cols) > 0) {

--- a/R/logit_utils.R
+++ b/R/logit_utils.R
@@ -72,7 +72,7 @@ invlogit <- function(x, domain_lower = 0, domain_upper = 1) {
 check_logit_inputs <- function(x, domain_lower, domain_upper) {
 
   # check numeric, input lengths, and lower < upper
-  assertive::assert_is_numeric(c(x, domain_lower, domain_upper))
+  checkmate::assert_numeric(c(x, domain_lower, domain_upper))
   assertthat::assert_that(length(domain_lower) %in% c(1, length(x)) &
                             length(domain_upper) %in% c(1, length(x)),
                           msg = "`domain_lower` and `domain_upper` must be

--- a/R/summarize_dt.R
+++ b/R/summarize_dt.R
@@ -70,32 +70,30 @@ summarize_dt <- function(dt,
   # Validate arguments ------------------------------------------------------
 
   # check `summarize_cols` argument
-  assertive::assert_is_character(summarize_cols)
+  checkmate::assert_character(summarize_cols)
 
   # check `value_cols` argument
-  assertive::assert_is_character(value_cols)
+  checkmate::assert_character(value_cols)
 
   # check `id_cols` argument
-  assertive::assert_is_character(id_cols)
+  checkmate::assert_character(id_cols)
   assertthat::assert_that(all(summarize_cols %in% id_cols),
                           msg = "`id_cols` must include `summarize_cols`")
 
   # check `dt` argument
-  assertive::assert_is_data.table(dt)
+  checkmate::assert_data_table(dt)
   assertable::assert_colnames(dt, c(id_cols, value_cols), only_colnames = F,
                               quiet = T)
   assert_is_unique_dt(dt, id_cols)
 
   # check `summary_fun` argument
-  assertthat::assert_that(assertive::is_character(summary_fun) |
-                            assertive::is_empty(summary_fun),
+  assertthat::assert_that(is.character(summary_fun) | is.null(summary_fun),
                           all(sapply(summary_fun, methods::existsFunction)),
                           msg = "`summary_fun` must be a correspond to a defined
                           function")
 
   # check `probs` argument
-  assertthat::assert_that(assertive::is_numeric(probs) |
-                            assertive::is_empty(probs),
+  assertthat::assert_that(is.numeric(probs) | is.null(probs),
                           all(data.table::between(probs, 0, 1)),
                           msg = "`probs`` must be between 0 and 1
                           (or empty/null)")


### PR DESCRIPTION
Replace assertive package with checkmate package, since assertive is not on CRAN for R version 4.3.